### PR TITLE
Add option to set `page.date` automatically with the file creation date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 _site/
 Gemfile.lock
 spec/fixtures/_posts/1992-09-11-last-modified-at.md
+spec/fixtures/_posts/date-no.md
 spec/fixtures/.jekyll-metadata
 spec/fixtures/.jekyll-cache
 spec/dev/out.txt

--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ plugins:
 last-modified-at:
     date-format: '%d-%b-%y'
 ```
-
-You can also set `set-page-date: true` to have the plugin determine the datetime the file was first commited and use that to automatically set the post's default `date`.  This will use the file's `ctime` if there's no git information.
-
 For sites with lots of documents using `last_modified_at`, there may be render
 performance improvement via:
 
@@ -84,3 +81,18 @@ To format such a time, you'll need to rely on Liquid's `date` filter:
 ```
 
 (It's generally [more performant to use the `page.last_modified_at` version](https://github.com/gjtorikian/jekyll-last-modified-at/issues/24#issuecomment-55431108) of this plugin.)
+
+## `page.date`
+
+Additionally, you can have this plugin automatically set a default `date` value on every page based on when the file was **first** commited in git. To enable this, set `set-page-date` to `true` in your config yaml:
+
+ ```yml
+plugins:
+  - jekyll-last-modified-at
+
+last-modified-at:
+    set-page-date: true
+```
+
+If a post's date is already set via [the filename](https://jekyllrb.com/docs/posts/#creating-posts) or a page's date is set in its [frontmatter](https://jekyllrb.com/docs/variables/#page-variables), those values will override the value provided by this plugin. If a git date isn't available, `ctime` is used.
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ last-modified-at:
     date-format: '%d-%b-%y'
 ```
 
+You can also set `override-date: true` to have "last-modified-at" determine the datetime the file was first commited and use that to automatically set the post's `date` field.  Will use `ctime` if there's no git information.
+
 For sites with lots of documents using `last_modified_at`, there may be render
 performance improvement via:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ last-modified-at:
     date-format: '%d-%b-%y'
 ```
 
-You can also set `override-date: true` to have "last-modified-at" determine the datetime the file was first commited and use that to automatically set the post's `date` field.  Will use `ctime` if there's no git information.
+You can also set `set-page-date: true` to have the plugin determine the datetime the file was first commited and use that to automatically set the post's default `date`.  This will use the file's `ctime` if there's no git information.
 
 For sites with lots of documents using `last_modified_at`, there may be render
 performance improvement via:

--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ To format such a time, you'll need to rely on Liquid's `date` filter:
 
 ## `page.date`
 
-Additionally, you can have this plugin automatically set a default `date` value on every page based on when the file was **first** commited in git. To enable this, set `set-page-date` to `true` in your config yaml:
+Additionally, this plugin automatically sets a default `date` value on every page based on when the file was **first** commited in git. To disable this, set `set-page-date` to `false` in your config yaml:
 
  ```yml
 plugins:
   - jekyll-last-modified-at
 
 last-modified-at:
-    set-page-date: true
+    set-page-date: false
 ```
 
 If a post's date is already set via [the filename](https://jekyllrb.com/docs/posts/#creating-posts) or a page's date is set in its [frontmatter](https://jekyllrb.com/docs/variables/#page-variables), those values will override the value provided by this plugin. If a git date isn't available, `ctime` is used.

--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -28,7 +28,6 @@ module Jekyll
         return self.class.repo_cache[site_source] unless self.class.repo_cache[site_source].nil?
 
         self.class.repo_cache[site_source] = Git.new(site_source)
-        self.class.repo_cache[site_source]
       end
 
       def formatted_last_modified_date
@@ -45,7 +44,6 @@ module Jekyll
         raise Errno::ENOENT, "#{absolute_path_to_article} does not exist!" unless File.exist? absolute_path_to_article
 
         self.class.first_mod_cache[page_path] = Time.at(first_modified_at_unix.to_i)
-        self.class.first_mod_cache[page_path]
       end
 
       def first_modified_at_unix

--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -16,7 +16,7 @@ module Jekyll
       attr_reader :site_source, :page_path, :use_git_cache
       attr_accessor :format
 
-      def initialize(site_source, page_path, format = nil, use_git_cache = true, first_time = true) # rubocop:disable Style/OptionalBooleanParameter
+      def initialize(site_source, page_path, format = nil, use_git_cache = true, first_time = false) # rubocop:disable Style/OptionalBooleanParameter
         @site_source   = site_source
         @page_path     = page_path
         @format        = format || '%d-%b-%y'
@@ -70,6 +70,14 @@ module Jekyll
           last_commit_date.nil? || last_commit_date.empty? ? mtime(absolute_path_to_article) : last_commit_date
         else
           mtime(absolute_path_to_article)
+        end
+      end
+
+      def to_i
+        if @first_time
+          @to_i ||= first_modified_at_unix.to_i
+        else
+          @to_i ||= last_modified_at_unix.to_i
         end
       end
 

--- a/lib/jekyll-last-modified-at/git.rb
+++ b/lib/jekyll-last-modified-at/git.rb
@@ -65,6 +65,8 @@ module Jekyll
             '--git-dir',
             top_level_directory,
             'log',
+            '--follow',
+            '--diff-filter=A',
             '--format="%ct"',
             '--',
             path

--- a/lib/jekyll-last-modified-at/git.rb
+++ b/lib/jekyll-last-modified-at/git.rb
@@ -70,7 +70,7 @@ module Jekyll
             '--format="%ct"',
             '--',
             path
-          ).split("\n")[-1][/\d+/]
+          )&.split("\n")&[-1]&[/\d+/]
         end
       end
 

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -9,7 +9,7 @@ module Jekyll
           use_git_cache = item.site.config.dig('last-modified-at', 'use-git-cache')
           item.data['last_modified_at'] = Determinator.new(item.site.source, item.relative_path,
                                                            format, use_git_cache)
-          if item.site.config.dig('last-modified-at', 'override-date')
+          if item.site.config.dig('last-modified-at', 'set-page-date')
             # The "date" field will be converted to a string first by Jekyll and it must be
             # in the format given below: https://jekyllrb.com/docs/variables/#page-variables
             item.data['date'] = Determinator.new(item.site.source, item.relative_path,

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -9,16 +9,13 @@ module Jekyll
           use_git_cache = item.site.config.dig('last-modified-at', 'use-git-cache')
           item.data['last_modified_at'] = Determinator.new(item.site.source, item.relative_path,
                                                            format, use_git_cache)
+          if item.site.config.dig('last-modified-at', 'override-date')
+            # The "date" field will be converted to a string first by Jekyll and it must be
+            # in the format given below: https://jekyllrb.com/docs/variables/#page-variables
+            item.data['date'] = Determinator.new(item.site.source, item.relative_path,
+                                                 '%Y-%m-%d %H:%M:%S %z', use_git_cache, true)
+          end
         }
-      end
-
-      Jekyll::Hooks.register :site, :after_reset do |site|
-        use_git_cache = site.config.dig('last-modified-at', 'use-git-cache')
-        if use_git_cache
-          # flush the caches so we can detect commits while server is running
-          Determinator.repo_cache = {}
-          Determinator.path_cache = {}
-        end
       end
 
       Jekyll::Hooks.register :posts, :post_init, &Hook.add_determinator_proc

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -6,10 +6,10 @@ module Jekyll
       def self.add_determinator_proc
         proc { |item|
           format = item.site.config.dig('last-modified-at', 'date-format')
-          use_git_cache = item.site.config.dig('last-modified-at', 'use-git-cache')
+          use_git_cache = item.site.config.dig('last-modified-at', 'use-git-cache') != false
           item.data['last_modified_at'] = Determinator.new(item.site.source, item.relative_path,
                                                            format, use_git_cache)
-          if item.site.config.dig('last-modified-at', 'set-page-date')
+          if item.site.config.dig('last-modified-at', 'set-page-date') != false
             # The "date" field will be converted to a string first by Jekyll and it must be
             # in the format given below: https://jekyllrb.com/docs/variables/#page-variables
             item.data['date'] = Determinator.new(item.site.source, item.relative_path,

--- a/spec/fixtures/_layouts/date_with_format.html
+++ b/spec/fixtures/_layouts/date_with_format.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>date-with-format</title>
+  </head>
+  <body>
+    <span class="last-modified-at">Article created on {% page.date | date: %Y:%B:%A:%d %}</span>
+
+    {{ content }}
+  </body>
+</html>

--- a/spec/fixtures/_layouts/date_with_format.html
+++ b/spec/fixtures/_layouts/date_with_format.html
@@ -3,7 +3,7 @@
     <title>date-with-format</title>
   </head>
   <body>
-    <span class="last-modified-at">Article created on {% page.date | date: %Y:%B:%A:%d %}</span>
+    <span class="last-modified-at">Article created on {% page.date | date: "%Y:%B:%A:%d" %}</span>
 
     {{ content }}
   </body>

--- a/spec/fixtures/_posts/no-date.md
+++ b/spec/fixtures/_posts/no-date.md
@@ -1,0 +1,6 @@
+---
+title: Testing Last Modified At
+layout: date_with_format
+---
+
+Yay.

--- a/spec/jekyll-last-modified-at/date_spec.rb
+++ b/spec/jekyll-last-modified-at/date_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Date Tag' do
+  context 'A committed post file' do
+    def setup(file, layout)
+      @post = setup_post(file)
+      do_render(@post, layout)
+    end
+
+    it 'has date' do
+      setup('no-date.md', 'date_with_format.html')
+      expect(@post.output).to match(/Article created on 09-Nov-22/)
+    end
+  end
+
+  context 'An uncommitted post file' do
+    before(:all) do
+      cheater_file = 'no-date.md'
+      uncommitted_file = 'date_no.md'
+      duplicate_post(cheater_file, uncommitted_file)
+      @post = setup_post(uncommitted_file)
+      do_render(@post, 'date_with_format.html')
+    end
+
+    it 'has date' do
+      expect(@post.output).to match(Regexp.new("Article created on #{Time.new.utc.strftime('%d-%b-%y')}"))
+    end
+  end
+end


### PR DESCRIPTION
Adds support for a "first posted at" variable, placed in `page.date`, as submitted to [gjtorikian/jekyll-last-modified-at](https://github.com/gjtorikian/jekyll-last-modified-at/pull/91) by @buddhist-uni